### PR TITLE
Misc

### DIFF
--- a/sysctlchk.sh
+++ b/sysctlchk.sh
@@ -76,6 +76,11 @@ if [ ! -e "$f" ]; then
     usage
 fi
 
+if [ ! -f "$f" ]; then
+    echo "Input $f is not a file"
+    usage
+fi
+
 log "Loading reference file $f"
 
 if [ $logging -eq 1 ]; then

--- a/sysctlchk.sh
+++ b/sysctlchk.sh
@@ -5,6 +5,8 @@
 # This source code is licensed under the GPLv3 license found in the
 # LICENSE file in the root directory of this source tree.
 
+set -eu
+
 usage()
 {
     echo "Usage: $0 [OPTIONS]..."
@@ -67,7 +69,7 @@ log " '..\`''.)(OO  \   /    '..\`''.) /_) |OO  )  |  |   |  |\`-' |/_) |OO  )| 
 log ".-._)   \ |   /  /\_  .-._)   \ ||  |\`-'|   |  |  (|  '---.'||  |\`-'| |  .-.  ||  .   \   "
 log "\       / \`-./  /.__) \       /(_'  '--'\   |  |   |      |(_'  '--'\ |  | |  ||  |\   \  "
 log " \`-----'    \`--'       \`-----'    \`-----'   \`--'   \`------'   \`-----' \`--' \`--'\`--' '--'  "
-log
+log ""
 log ""
 
 
@@ -104,7 +106,7 @@ while read -r line; do
     fi
 
     refname=$(echo "$line" | cut -d' ' -f1)
-    cur=$(sysctl "$refname")
+    cur=$(sysctl "$refname") || true
 
     if [ "$line" = "$cur" ]; then
 	good=$((good + 1))


### PR DESCRIPTION
* Parse only regular files

  Avoid reading configuration from directories or other special file types.

* Fail on unset parameters and command failures

  Exempt sysctl(8) failures and provide argument for log() function.