### PR TITLE
Improve usability on embedded systems

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,13 @@ Usage: ./sysctlchk.sh [OPTIONS]...
 Check sysctl values against a reference file.
 
 Arguments:
-  -b print only failed entries
+  -b print only failed and not found entries
+     specify twice to only show failed entries
   -f reference file, format is as the 'sysctl -a' output
   -h display this help and exit
   -l log file to output to
   -v verbose mode
+  -y avoid usage of terminal escape sequences
 ```
 
 A simple, POSIX shell script to check sysctl values against a

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Default list, with output log:
 ![example 1](img/1.png "Example 1")
 
 Custom reference file, verbose, only displaying failed checks, with
-ouput log:
+output log:
 
 ```
 ./sysctlchk.sh -l sysctlchk.log -f /some/custom/file.conf -b -v

--- a/refs/all.conf
+++ b/refs/all.conf
@@ -1,4 +1,4 @@
-# A mix of all the below references and personnal decisions:
+# A mix of all the below references and personal decisions:
 # https://www.kernel.org/doc/Documentation/sysctl/fs.txt
 # https://www.ssi.gouv.fr/guide/recommandations-de-securite-relatives-a-un-systeme-gnulinux (v1.2)
 # https://wiki.archlinux.org/title/sysctl#TCP/IP_stack_hardening
@@ -111,11 +111,11 @@ kernel.sysctl_writes_strict = 1
 # Disable coredumps of SUID binaries
 fs.suid_dumpable = 0
 
-# Avoid certains TOCTOU attacks on files
+# Avoid certain TOCTOU attacks on files
 fs.protected_hardlinks = 1
 fs.protected_symlinks = 1
 
-# Avoid unitentionnal writes to attacker-controllled FIFOs and files
+# Avoid unitentionnal writes to attacker-controlled FIFOs and files
 # value could also be 2
 fs.protected_fifos = 1
 fs.protected_regular = 1

--- a/sysctlchk.sh
+++ b/sysctlchk.sh
@@ -115,10 +115,17 @@ while read -r line; do
 
     refname=$(echo "$line" | cut -d' ' -f1)
     retcode=0
-    cur=$(sysctl -e "$refname") || retcode=$?
+    cur=$(sysctl -e "$refname" 2>&1) || retcode=$?
 
     if [ "$retcode" -ne 0 ]; then
 	error=$((error + 1))
+
+	if [ $color -eq 1 ]; then
+	    log "\e[1;35m[!]\e[0m $refname: $cur"
+	else
+	    log "[!] $refname: $cur"
+	fi
+
 	continue
     elif [ "$line" = "$cur" ]; then
 	good=$((good + 1))


### PR DESCRIPTION
* add option to avoid terminal escape sequences (used for coloring) in case they are not supported by the terminal in use
* differentiate between a systctl value having a non desired value and the key not existing on the current system